### PR TITLE
Adds neuroglancer acctions to results tab topbar

### DIFF
--- a/scripts/convert.ts
+++ b/scripts/convert.ts
@@ -1,0 +1,176 @@
+// Description: Code to convert neuroglancer state objects to and from url safe strings
+// Usage: bun convert.ts
+
+
+const SINGLE_QUOTE_STRING_PATTERN = /('(?:[^'\\]|(?:\\.))*')/;
+const DOUBLE_QUOTE_STRING_PATTERN = /("(?:[^"\\]|(?:\\.))*")/;
+const SINGLE_OR_DOUBLE_QUOTE_STRING_PATTERN =
+    new RegExp(`${SINGLE_QUOTE_STRING_PATTERN.source}|${DOUBLE_QUOTE_STRING_PATTERN.source}`);
+const DOUBLE_OR_SINGLE_QUOTE_STRING_PATTERN =
+    new RegExp(`${DOUBLE_QUOTE_STRING_PATTERN.source}|${SINGLE_QUOTE_STRING_PATTERN.source}`);
+
+const DOUBLE_QUOTE_PATTERN = /^((?:[^"'\\]|(?:\\[^']))*)("|\\')/;
+const SINGLE_QUOTE_PATTERN = /^((?:[^"'\\]|(?:\\.))*)'/;
+
+function convertStringLiteral(
+  x: string, quoteInitial: string, quoteReplace: string, quoteSearch: RegExp) {
+  if (x.length >= 2 && x.charAt(0) === quoteInitial && x.charAt(x.length - 1) === quoteInitial) {
+    let inner = x.substr(1, x.length - 2);
+    let s = quoteReplace;
+    while (inner.length > 0) {
+      const m = inner.match(quoteSearch);
+      if (m === null) {
+        s += inner;
+        break;
+      }
+      s += m[1];
+      if (m[2] === quoteReplace) {
+        // We received a single unescaped quoteReplace character.
+        s += '\\';
+        s += quoteReplace;
+      } else {
+        // We received "\\" + quoteInitial.  We need to remove the escaping.
+        s += quoteInitial;
+      }
+      inner = inner.substr(m.index! + m[0].length);
+    }
+    s += quoteReplace;
+    return s;
+  }
+  return x;
+}
+
+function convertJsonHelper(x: string, desiredCommaChar: string, desiredQuoteChar: string) {
+  const commaSearch = /[&_,]/g;
+  let quoteInitial: string;
+  let quoteSearch: RegExp;
+  let stringLiteralPattern: RegExp;
+  if (desiredQuoteChar === '"') {
+    quoteInitial = '\'';
+    quoteSearch = DOUBLE_QUOTE_PATTERN;
+    stringLiteralPattern = SINGLE_OR_DOUBLE_QUOTE_STRING_PATTERN;
+  } else {
+    quoteInitial = '"';
+    quoteSearch = SINGLE_QUOTE_PATTERN;
+    stringLiteralPattern = DOUBLE_OR_SINGLE_QUOTE_STRING_PATTERN;
+  }
+  let s = '';
+  while (x.length > 0) {
+    const m = x.match(stringLiteralPattern);
+    let before: string;
+    let replacement: string;
+    if (m === null) {
+      before = x;
+      x = '';
+      replacement = '';
+    } else {
+      before = x.substr(0, m.index);
+      x = x.substr(m.index! + m[0].length);
+      const originalString = m[1];
+      if (originalString !== undefined) {
+        replacement =
+            convertStringLiteral(originalString, quoteInitial, desiredQuoteChar, quoteSearch);
+      } else {
+        replacement = m[2];
+      }
+    }
+    s += before.replace(commaSearch, desiredCommaChar);
+    s += replacement;
+  }
+  return s;
+}
+
+function urlSafeToJSON(x: string) {
+  return convertJsonHelper(x, ',', '"');
+}
+
+function urlSafeParse(x: string) {
+  return JSON.parse(urlSafeToJSON(x));
+}
+
+
+
+const encoded = '%7B%22dimensions%22:%7B%22x%22:%5B8e-9%2C%22m%22%5D%2C%22y%22:%5B8e-9%2C%22m%22%5D%2C%22z%22:%5B8e-9%2C%22m%22%5D%7D%2C%22position%22:%5B17213.5%2C19862.5%2C20697.5%5D%2C%22crossSectionScale%22:1%2C%22projectionScale%22:65535.999999999985%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%22precomputed://gs://neuroglancer-janelia-flyem-hemibrain/emdata/clahe_yz/jpeg%22%2C%22tab%22:%22source%22%2C%22name%22:%22hemibrain:v1.2.1-grayscalejpeg%22%7D%2C%7B%22type%22:%22segmentation%22%2C%22source%22:%22precomputed://gs://neuroglancer-janelia-flyem-hemibrain/v1.2/segmentation%22%2C%22tab%22:%22source%22%2C%22segments%22:%5B%22734814622%22%2C%22769263962%22%5D%2C%22name%22:%22hemibrain:v1.2.1%22%7D%2C%7B%22type%22:%22annotation%22%2C%22source%22:%22dvid://https://hemibrain-dvid.janelia.org/3159/public_annotations?usertag=true&auth=https://hemibrain-dvid.janelia.org/api/server/token%22%2C%22tool%22:%22annotatePoint%22%2C%22tab%22:%22source%22%2C%22annotationColor%22:%22#ff0000%22%2C%22shader%22:%22#uicontrol%20vec3%20falseSplitColor%20color%28default=%5C%22#F08040%5C%22%29%5Cn#uicontrol%20vec3%20falseMergeColor%20color%28default=%5C%22#F040F0%5C%22%29%5Cn#uicontrol%20vec3%20checkedColor%20color%28default=%5C%22green%5C%22%29%5Cn#uicontrol%20vec3%20borderColor%20color%28default=%5C%22black%5C%22%29%5Cn%5Cn#uicontrol%20float%20radius%20slider%28min=3%2C%20max=20%2C%20step=1%2C%20default=10%29%5Cn#uicontrol%20float%20opacity%20slider%28min=0%2C%20max=1%2C%20step=0.1%2C%20default=1%29%20%20%5Cn%5Cnvoid%20main%28%29%20%7B%5Cn%20%20setPointMarkerSize%28radius%29%3B%5Cn%20%20float%20finalOpacity%20=%20PROJECTION_VIEW%20?%20opacity%20%2A%200.2%20:%20opacity%3B%5Cn%5Cn%20%20setPointMarkerBorderColor%28vec4%28borderColor%2C%20finalOpacity%29%29%3B%5Cn%20%20if%20%28prop_rendering_attribute%28%29%20==%201%29%20%7B%5Cn%20%20%20%20setColor%28vec4%28checkedColor%2C%20finalOpacity%29%29%3B%5Cn%20%20%7D%20else%20if%20%28prop_rendering_attribute%28%29%20==%202%29%20%7B%20%20%20%20%5Cn%20%20%20%20setColor%28vec4%28falseSplitColor%2C%20finalOpacity%29%29%3B%5Cn%20%20%7D%20else%20if%20%28prop_rendering_attribute%28%29%20==%203%29%20%20%7B%5Cn%20%20%20%20setColor%28vec4%28falseMergeColor%2C%20finalOpacity%29%29%3B%5Cn%20%20%7D%20else%20%7B%5Cn%20setColor%28vec4%281%2C%200%2C%200%2C%20finalOpacity%29%29%3B%5Cn%20%20%7D%5Cn%7D%22%2C%22name%22:%22hemibrain:v1.2.1-public_annotations%22%7D%2C%7B%22type%22:%22annotation%22%2C%22source%22:%22precomputed://gs://neuroglancer-janelia-flyem-hemibrain/v1.2/synapses%22%2C%22tab%22:%22source%22%2C%22shader%22:%22#uicontrol%20vec3%20preColor%20color%28default=%5C%22yellow%5C%22%29%5Cn#uicontrol%20vec3%20postColor%20color%28default=%5C%22gray%5C%22%29%5Cn#uicontrol%20float%20preConfidence%20slider%28min=0%2C%20max=1%2C%20default=0%29%5Cn#uicontrol%20float%20postConfidence%20slider%28min=0%2C%20max=1%2C%20default=0%29%5Cn#uicontrol%20float%20sliceViewOpacity%20slider%28min=0%2C%20max=1%2C%20default=0.5%29%5Cn#uicontrol%20float%20projectionViewOpacity%20slider%28min=0%2C%20max=1%2C%20default=0.3%29%5Cn%5Cnvoid%20main%28%29%20%7B%5Cn%20%20float%20opacity%20=%20PROJECTION_VIEW%20?%20projectionViewOpacity%20:%20sliceViewOpacity%3B%5Cn%20%20setColor%28vec4%28defaultColor%28%29%2C%20opacity%29%29%3B%5Cn%20%20setEndpointMarkerColor%28%5Cn%20%20%20%20vec4%28preColor%2C%20opacity%29%2C%5Cn%20%20%20%20vec4%28postColor%2C%20opacity%29%29%3B%5Cn%20%20setEndpointMarkerBorderColor%28%5Cn%20%20%20%20vec4%280%2C%200%2C%200%2C%20opacity%29%2C%5Cn%20%20%20%20vec4%280%2C%200%2C%200%2C%20%20%20%20%20opacity%29%5Cn%20%20%29%3B%5Cn%5Cn%20%20setEndpointMarkerSize%285.0%2C%205.0%29%3B%5Cn%20%20setLineWidth%282.0%29%3B%5Cn%20%20if%20%28prop_pre_synaptic_confidence%28%29%3C%20preConfidence%20%7C%7C%5Cn%20%20prop_post_synaptic_confidence%28%29%3C%20postConfidence%29%20discard%3B%5Cn%7D%5Cn%22%2C%22linkedSegmentationLayer%22:%7B%22pre_synaptic_cell%22:%22hemibrain:v1.2.1%22%2C%22post_synaptic_cell%22:%22hemibrain:v1.2.1%22%7D%2C%22filterBySegmentation%22:%5B%22post_synaptic_cell%22%2C%22pre_synaptic_cell%22%5D%2C%22name%22:%22hemibrain:v1.2.1-synapses%22%7D%5D%2C%22layout%22:%22xy-3d%22%7D'
+
+const decoded = decodeURIComponent(encoded)
+const state = urlSafeParse(decoded)
+
+
+console.log(state)
+
+const raw = {
+  "dimensions": {
+    "x": [
+      8e-9,
+      "m"
+    ],
+    "y": [
+      8e-9,
+      "m"
+    ],
+    "z": [
+      8e-9,
+      "m"
+    ]
+  },
+  "position": [
+    17213.5,
+    19862.5,
+    20697.5
+  ],
+  "crossSectionScale": 1,
+  "projectionScale": 65535.999999999985,
+  "layers": [
+    {
+      "type": "image",
+      "source": "precomputed://gs://neuroglancer-janelia-flyem-hemibrain/emdata/clahe_yz/jpeg",
+      "tab": "source",
+      "name": "hemibrain:v1.2.1-grayscalejpeg"
+    },
+    {
+      "type": "segmentation",
+      "source": "precomputed://gs://neuroglancer-janelia-flyem-hemibrain/v1.2/segmentation",
+      "tab": "source",
+      "segments": [
+        "734814622",
+        "769263962"
+      ],
+      "name": "hemibrain:v1.2.1"
+    },
+    {
+      "type": "annotation",
+      "source": "dvid://https://hemibrain-dvid.janelia.org/3159/public_annotations?usertag=true&auth=https://hemibrain-dvid.janelia.org/api/server/token",
+      "tool": "annotatePoint",
+      "tab": "source",
+      "annotationColor": "#ff0000",
+      "shader": "#uicontrol vec3 falseSplitColor color(default=\"#F08040\")\n#uicontrol vec3 falseMergeColor color(default=\"#F040F0\")\n#uicontrol vec3 checkedColor color(default=\"green\")\n#uicontrol vec3 borderColor color(default=\"black\")\n\n#uicontrol float radius slider(min=3, max=20, step=1, default=10)\n#uicontrol float opacity slider(min=0, max=1, step=0.1, default=1)  \n\nvoid main() {\n  setPointMarkerSize(radius);\n  float finalOpacity = PROJECTION_VIEW ? opacity * 0.2 : opacity;\n\n  setPointMarkerBorderColor(vec4(borderColor, finalOpacity));\n  if (prop_rendering_attribute() == 1) {\n    setColor(vec4(checkedColor, finalOpacity));\n  } else if (prop_rendering_attribute() == 2) {    \n    setColor(vec4(falseSplitColor, finalOpacity));\n  } else if (prop_rendering_attribute() == 3)  {\n    setColor(vec4(falseMergeColor, finalOpacity));\n  } else {\n setColor(vec4(1, 0, 0, finalOpacity));\n  }\n}",
+      "name": "hemibrain:v1.2.1-public_annotations"
+    },
+    {
+      "type": "annotation",
+      "source": "precomputed://gs://neuroglancer-janelia-flyem-hemibrain/v1.2/synapses",
+      "tab": "source",
+      "shader": "#uicontrol vec3 preColor color(default=\"yellow\")\n#uicontrol vec3 postColor color(default=\"gray\")\n#uicontrol float preConfidence slider(min=0, max=1, default=0)\n#uicontrol float postConfidence slider(min=0, max=1, default=0)\n#uicontrol float sliceViewOpacity slider(min=0, max=1, default=0.5)\n#uicontrol float projectionViewOpacity slider(min=0, max=1, default=0.3)\n\nvoid main() {\n  float opacity = PROJECTION_VIEW ? projectionViewOpacity : sliceViewOpacity;\n  setColor(vec4(defaultColor(), opacity));\n  setEndpointMarkerColor(\n    vec4(preColor, opacity),\n    vec4(postColor, opacity));\n  setEndpointMarkerBorderColor(\n    vec4(0, 0, 0, opacity),\n    vec4(0, 0, 0,     opacity)\n  );\n\n  setEndpointMarkerSize(5.0, 5.0);\n  setLineWidth(2.0);\n  if (prop_pre_synaptic_confidence()< preConfidence ||\n  prop_post_synaptic_confidence()< postConfidence) discard;\n}\n",
+      "linkedSegmentationLayer": {
+        "pre_synaptic_cell": "hemibrain:v1.2.1",
+        "post_synaptic_cell": "hemibrain:v1.2.1"
+      },
+      "filterBySegmentation": [
+        "post_synaptic_cell",
+        "pre_synaptic_cell"
+      ],
+      "name": "hemibrain:v1.2.1-synapses"
+    }
+  ],
+  "layout": "xy-3d"
+};
+
+function encodeFragment(fragment: string) {
+  return encodeURI(fragment).replace(/[!'()*;,]/g, function(c) {
+    return '%' + c.charCodeAt(0).toString(16).toUpperCase();
+  });
+}
+
+
+const encodedFragment = encodeFragment(JSON.stringify(raw));
+console.log(encodedFragment)

--- a/src/js/actions/plugins.js
+++ b/src/js/actions/plugins.js
@@ -115,6 +115,12 @@ export function fetchData(params, plugin, tabPosition, token) {
     } else if (fetchParams.cypherQuery) {
       parameters.cypher = fetchParams.cypherQuery;
     }
+    // TODO: remove this when all plugins are updated to allow neuron_ids as strings
+
+    // convert neuron_id to integer if it is a string (for backward compatibility)
+    if (parameters.neuron_id) {
+      parameters.neuron_id = parseInt(parameters.neuron_id, 10);
+    }
 
     const body = (fetchParams.method === 'GET') ? null : JSON.stringify(parameters);
 

--- a/src/js/components/Result.jsx
+++ b/src/js/components/Result.jsx
@@ -352,6 +352,7 @@ class Result extends React.Component {
                   downloadEnabled={downloadEnabled}
                   saveEnabled={saveEnabled}
                   addIdEnabled={Boolean(processingPlugin.details.visType === 'SkeletonView')}
+                  isNeuroglancer={Boolean(processingPlugin.details.visType === 'NeuroglancerView')}
                   downloadCallback={this.downloadFile}
                   download3DCallback={download3DCallback}
                   clipboardCallback={clipboardCallback}

--- a/src/js/components/Result.jsx
+++ b/src/js/components/Result.jsx
@@ -245,6 +245,8 @@ class Result extends React.Component {
 
     const query = getQueryObject();
     const resultsList = query.qr || [];
+    const currentPlugin = this.currentPlugin();
+
 
     if (!loading.get(tabIndex, false) && resultsList.length === 0) {
       return (
@@ -258,6 +260,40 @@ class Result extends React.Component {
         </div>
       );
     }
+
+    // Return early with a way to close the tab, if an error
+    // occurred loading the data. Maybe add a try again button.
+
+    if (!loading.get(tabIndex, false) && loadingError.get(tabIndex)) {
+      return (
+        <div className={classes.scroll}>
+          <div className={classes.full}>
+            <ResultsTopBar
+              downloadCallback={this.downloadFile}
+              downloadEnabled={false}
+              saveEnabled={false}
+              name="Error loading content"
+              index={tabIndex}
+              queryStr="error"
+              color="#ffcccc"
+              fixed={fixed}
+              dataSet={resultsList[tabIndex].ds}
+            />
+            {/*
+            Some of the error messages are returned from the server as plain text with
+            a set amount of white space used to indicate where the error occurs. So
+            placing them in a pre tag preserves the indicator location in a web
+            page.
+              */}
+            <div>
+              <pre className={classes.errorText}>{loadingError.get(tabIndex).toString()}</pre>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+
 
     let tabData = (
       <div className={classes.full}>
@@ -284,7 +320,6 @@ class Result extends React.Component {
         cachedResults.params &&
         cachedResults.params.code === resultsList[tabIndex].code
       ) {
-        const currentPlugin = this.currentPlugin();
 
         if (currentPlugin) {
           // TODO: here is where we should trigger the loading of the view plugins. It is only at this
@@ -442,36 +477,6 @@ class Result extends React.Component {
           }
         }
       }
-    }
-
-    // Return here with a way to close the tab, if an error
-    // occurred loading the data. Maybe add a try again button.
-
-    if (!loading.get(tabIndex, false) && loadingError.get(tabIndex)) {
-      tabData = (
-        <div className={classes.full}>
-          <ResultsTopBar
-            downloadCallback={this.downloadFile}
-            downloadEnabled={false}
-            saveEnabled={false}
-            name="Error loading content"
-            index={tabIndex}
-            queryStr="error"
-            color="#ffcccc"
-            fixed={fixed}
-            dataSet={resultsList[tabIndex].ds}
-          />
-          {/*
-           Some of the error messages are returned from the server as plain text with
-           a set amount of white space used to indicate where the error occurs. So
-           placing them in a pre tag preserves the indicator location in a web
-           page.
-            */}
-          <div>
-            <pre className={classes.errorText}>{loadingError.get(tabIndex).toString()}</pre>
-          </div>
-        </div>
-      );
     }
 
     return <div className={classes.scroll}>{tabData}</div>;

--- a/src/js/components/Result.jsx
+++ b/src/js/components/Result.jsx
@@ -218,10 +218,13 @@ class Result extends React.Component {
     const { pluginList, tabIndex } = this.props;
     const query = getQueryObject();
     const resultsList = query.qr || [];
-    const currentPlugin = pluginList.find(
-      plugin => plugin.details.abbr === resultsList[tabIndex].code
-    );
-    return currentPlugin;
+    if (resultsList[tabIndex]) {
+      const currentPlugin = pluginList.find(
+        plugin => plugin.details.abbr === resultsList[tabIndex].code
+      );
+      return currentPlugin;
+    }
+    return null;
   }
 
   render() {

--- a/src/js/components/ResultsTopBar.jsx
+++ b/src/js/components/ResultsTopBar.jsx
@@ -34,6 +34,7 @@ import C from '../reducers/constants';
 import CachedCounter from './ResultsTopBar/CachedCounter';
 import AddIdModal from './ResultsTopBar/AddIdModal';
 import CopyToClipboardModal from './ResultsTopBar/CopyToClipboardModal';
+import NeuroglancerMenu from './ResultsTopBar/NeuroglancerMenu';
 
 const styles = (theme) => ({
   root: {
@@ -68,6 +69,7 @@ function ResultsTopBar({
   clipboardCallback=null,
   saveEnabled,
   addIdEnabled=false,
+  isNeuroglancer,
   actions,
   fetchedTime=new Date().getTime(),
   dataSet='loading',
@@ -86,7 +88,6 @@ function ResultsTopBar({
   const [bookmarkname, setBookmarkname] = React.useState('');
   const [anchorEl, setAnchorEl] = React.useState(null);
   const { width, ref } = useResizeDetector();
-
 
   const handleCloseMenu = () => {
     setAnchorEl(null);
@@ -204,7 +205,11 @@ function ResultsTopBar({
   };
 
   return (
-    <div ref={ref} className={classNames(classes.root, 'topresultbar')} style={{ backgroundColor: color }}>
+    <div
+      ref={ref}
+      className={classNames(classes.root, 'topresultbar')}
+      style={{ backgroundColor: color }}
+    >
       <Toolbar>
         <Typography variant="caption" color="inherit" className={classes.flex} noWrap>
           {dataSet} - {name}
@@ -310,6 +315,9 @@ function ResultsTopBar({
                 <Icon style={{ fontSize: 18 }}>push_pin</Icon>
               </IconButton>
             </Tooltip>
+            {isNeuroglancer ? (
+              <NeuroglancerMenu dataSet={dataSet} />
+            ) : null}
 
             {download3DCallback && (
               <Tooltip title="Download VR viewer seed">
@@ -509,6 +517,7 @@ ResultsTopBar.propTypes = {
   visibleColumns: PropTypes.object,
   resultData: PropTypes.object,
   addIdEnabled: PropTypes.bool,
+  isNeuroglancer: PropTypes.bool,
   saveEnabled: PropTypes.bool.isRequired,
   queryStr: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,

--- a/src/js/components/ResultsTopBar.jsx
+++ b/src/js/components/ResultsTopBar.jsx
@@ -204,6 +204,9 @@ function ResultsTopBar({
     }
   };
 
+  const result = results.get(index);
+  const data = result ? result.result : null;
+
   return (
     <div
       ref={ref}
@@ -316,7 +319,7 @@ function ResultsTopBar({
               </IconButton>
             </Tooltip>
             {isNeuroglancer ? (
-              <NeuroglancerMenu dataSet={dataSet} />
+              <NeuroglancerMenu dataSet={dataSet} ngState={data} />
             ) : null}
 
             {download3DCallback && (

--- a/src/js/components/ResultsTopBar/NeuroglancerMenu.jsx
+++ b/src/js/components/ResultsTopBar/NeuroglancerMenu.jsx
@@ -6,13 +6,11 @@ import Tooltip from '@material-ui/core/Tooltip';
 import IconButton from '@material-ui/core/IconButton';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
-import Icon from '@material-ui/core/Icon';
 import HistoryIcon from '@material-ui/icons/History';
 import ToggleOffIcon from '@material-ui/icons/ToggleOff';
 
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import MenuIcon from '@material-ui/icons/Menu';
-import Assignment from '@material-ui/icons/Assignment';
 
 import { NgViewerContext } from 'contexts/NgViewerContext';
 
@@ -128,6 +126,8 @@ function NeuroglancerMenu({ classes, dataSet }) {
   }
 
   const handleSkeletonMeshToggle = () => {
+    // TODO: implement the skeleton/mesh toggle
+    // eslint-disable-next-line no-console
     console.log('handleSkeletonMeshToggle');
   }
 

--- a/src/js/components/ResultsTopBar/NeuroglancerMenu.jsx
+++ b/src/js/components/ResultsTopBar/NeuroglancerMenu.jsx
@@ -1,0 +1,206 @@
+import PropTypes from 'prop-types';
+import React, { useContext, useState } from 'react';
+
+import { withStyles } from '@material-ui/core/styles';
+import Tooltip from '@material-ui/core/Tooltip';
+import IconButton from '@material-ui/core/IconButton';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import Icon from '@material-ui/core/Icon';
+import HistoryIcon from '@material-ui/icons/History';
+import ToggleOffIcon from '@material-ui/icons/ToggleOff';
+
+import OpenInNewIcon from '@material-ui/icons/OpenInNew';
+import MenuIcon from '@material-ui/icons/Menu';
+import Assignment from '@material-ui/icons/Assignment';
+
+import { NgViewerContext } from 'contexts/NgViewerContext';
+
+const styles = (theme) => ({
+  root: {
+    width: '100%',
+    flexGrow: true,
+  },
+  flex: {
+    flex: 1,
+  },
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+  },
+  cachedTime: {
+    color: '#555',
+  },
+  menuIcon: {
+    fontSize: 18,
+    marginRight: theme.spacing(2),
+  },
+});
+
+// Convert the neuroglancer state into a URL fragment.
+// Copied from the neuroglancer source code.
+function encodeFragment(fragment) {
+  return encodeURI(fragment).replace(
+    /[!'()*;,]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
+  );
+}
+
+function NeuroglancerMenu({ classes, dataSet }) {
+  const { ngViewerState, setNgViewerState } = useContext(NgViewerContext);
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleCloseMenu = () => {
+    setAnchorEl(null);
+  };
+
+  const handleOpenMenu = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleOpenInNewWindow = () => {
+    // grab the neuroglancer state for this dataset
+    const tabState = ngViewerState[dataSet];
+    const encodedState = encodeFragment(JSON.stringify(tabState));
+    // convert it into a URL
+    const url = `https://clio-ng.janelia.org/#!${encodedState}`;
+    // open a new window with that URL
+    window.open(url, '_blank');
+  };
+
+  const handleResetViewToBrain = () => {
+    setNgViewerState((prevState) => {
+      const newState = { ...prevState, [dataSet]: { ...prevState[dataSet], perspectiveZoom: 80 } };
+      return newState;
+    });
+    handleCloseMenu();
+  };
+
+  const handleResetViewToVNC = () => {
+    setNgViewerState((prevState) => {
+      const newState = { ...prevState, [dataSet]: { ...prevState[dataSet], perspectiveZoom: 200 } };
+      return newState;
+    });
+    handleCloseMenu();
+  };
+
+  const handleSynapseToggle = () => {
+    setNgViewerState((prevState) => {
+      // find the layer that has a name containing 'synapse'
+      const tabState = prevState[dataSet];
+      const layerOfInterest = tabState.layers.find((layer) => layer.name.includes('synapse'));
+
+      // set the synapse layer to be visible or not visible depending on the current state
+      if (layerOfInterest) {
+        // if layerOfInterest.visible is missing, set it to be false
+        if (layerOfInterest.visible === undefined) {
+          layerOfInterest.visible = false;
+        } else {
+          layerOfInterest.visible = !layerOfInterest.visible;
+        }
+      }
+      const newState = { ...prevState, [dataSet]: tabState };
+      return newState;
+    });
+    handleCloseMenu();
+  }
+
+  const handleROIToggle = () => {
+    setNgViewerState((prevState) => {
+      // find the layer that has a name containing 'ROI'
+      const tabState = prevState[dataSet];
+      const layerOfInterest = tabState.layers.find((layer) => layer.name.includes('roi'));
+
+      // set the ROI layer to be visible or not visible depending on the current state
+      if (layerOfInterest) {
+        // if layerOfInterest.visible is missing, set it to be false
+        if (layerOfInterest.visible === undefined) {
+          layerOfInterest.visible = false;
+        } else {
+          layerOfInterest.visible = !layerOfInterest.visible;
+        }
+      }
+      const newState = { ...prevState, [dataSet]: tabState };
+      return newState;
+    });
+    handleCloseMenu();
+  }
+
+  const handleSkeletonMeshToggle = () => {
+    console.log('handleSkeletonMeshToggle');
+  }
+
+  return (
+    <>
+      <Tooltip title="Neuroglancer Actions">
+        <IconButton
+          className={classes.button}
+          aria-label="Neuroglancer Menu"
+          onClick={handleOpenMenu}
+        >
+          <MenuIcon style={{ fontSize: 18 }} />
+        </IconButton>
+      </Tooltip>
+      <Menu id="simple-menu" anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleCloseMenu}>
+        <MenuItem
+          aria-label="Reset to default brain view"
+          onClick={() => {
+            handleResetViewToBrain();
+          }}
+        >
+          <HistoryIcon className={classes.menuIcon} /> Reset to default brain view
+        </MenuItem>
+        <MenuItem
+          aria-label="Reset to default VNC view"
+          onClick={() => {
+            handleResetViewToVNC();
+          }}
+        >
+          <HistoryIcon className={classes.menuIcon} /> Reset to default VNC view
+        </MenuItem>
+        <MenuItem
+          aria-label="Switch between meshes and skeletons"
+          onClick={() => {
+            handleSkeletonMeshToggle();
+          }}
+        >
+          <ToggleOffIcon className={classes.menuIcon} /> Switch between meshes and skeletons
+        </MenuItem>
+        <MenuItem
+          aria-label="Toggle synapses"
+          onClick={() => {
+            handleSynapseToggle();
+          }}
+        >
+          <ToggleOffIcon className={classes.menuIcon} /> Toggle synapses
+        </MenuItem>
+        <MenuItem
+          aria-label="Toggle ROIs"
+          onClick={() => {
+            handleROIToggle();
+          }}
+        >
+          <ToggleOffIcon className={classes.menuIcon} /> Toggle ROIs
+        </MenuItem>
+      </Menu>
+
+      <Tooltip title="Open in new window">
+        <IconButton
+          className={classes.button}
+          aria-label="Open in new window"
+          onClick={handleOpenInNewWindow}
+        >
+          <OpenInNewIcon style={{ fontSize: 18 }} />
+        </IconButton>
+      </Tooltip>
+    </>
+  );
+}
+
+NeuroglancerMenu.propTypes = {
+  classes: PropTypes.object.isRequired,
+  dataSet: PropTypes.string.isRequired,
+};
+
+export default withStyles(styles)(NeuroglancerMenu);

--- a/src/js/components/Workstation.jsx
+++ b/src/js/components/Workstation.jsx
@@ -95,7 +95,7 @@ export default function Workstation(props) {
       pm: {
         all_segment: false,
         dataset: dataset || defaultDataset,
-        neuron_id: bodyid
+        neuron_id: parseInt(bodyid, 10)
       }
     };
   }

--- a/src/js/components/Workstation.jsx
+++ b/src/js/components/Workstation.jsx
@@ -100,7 +100,7 @@ export default function Workstation(props) {
     };
   }
 
-  // set up the two tabs, one for the skeleton and one for the find neurons tab.
+  // set up the two tabs, one for neuroglancer and one for the find neurons tab.
   const redirectQuery = {
     q: 0,
     tab,
@@ -114,7 +114,6 @@ export default function Workstation(props) {
         pm: {
           bodyIds,
           dataset: dataset || defaultDataset,
-          skip: true
         }
       }
     ]

--- a/src/js/plugins/query/FindNeurons.jsx
+++ b/src/js/plugins/query/FindNeurons.jsx
@@ -639,7 +639,7 @@ export class FindNeurons extends React.Component {
 
     if (neuronInstance !== '') {
       if (/^\d+$/.test(neuronInstance)) {
-        parameters.neuron_id = neuronInstance;
+        parameters.neuron_id = parseInt(neuronInstance, 10);
       } else {
         parameters.neuron_name = neuronInstance;
       }

--- a/src/js/plugins/query/Neuroglancer.jsx
+++ b/src/js/plugins/query/Neuroglancer.jsx
@@ -32,15 +32,17 @@ class Neuroglancer extends React.Component {
     };
   }
 
-  static fetchParameters() {
+  static fetchParameters(params) {
     return {
-      skip: true
+      queryUrl: `/api/npexplorer/nglayers/${params.dataset}.json`,
+      method: 'GET',
     };
   }
 
-  static processResults({ query }) {
+  static processResults({ query, apiResponse }) {
     return {
       debug: 'No cypher query for this plugin',
+      data: apiResponse,
       title: `Neuroglancer viewer for ${query.pm.dataset}`,
     };
   };
@@ -62,7 +64,6 @@ class Neuroglancer extends React.Component {
       pluginCode: pluginAbbrev,
       parameters: {
         dataset: dataSet,
-        skip: true, // skip the data fetching in Requests.
         bodyIds
       },
     };

--- a/src/js/plugins/query/SimpleConnections.jsx
+++ b/src/js/plugins/query/SimpleConnections.jsx
@@ -266,7 +266,7 @@ export class SimpleConnections extends React.Component {
         parameters.enable_contains = true;
       }
       if (/^\d+$/.test(neuronName)) {
-        parameters.neuron_id = neuronName;
+        parameters.neuron_id = parseInt(neuronName, 10);
       } else {
         parameters.neuron_name = neuronName;
       }

--- a/src/js/plugins/query/shared/pluginhelpers.jsx
+++ b/src/js/plugins/query/shared/pluginhelpers.jsx
@@ -90,7 +90,7 @@ export function createSimpleConnectionQueryObject({ dataSet, isPost = false, que
     }
   };
   if (queryId) {
-    query.parameters.neuron_id = queryId;
+    query.parameters.neuron_id = parseInt(queryId, 10);
   } else if (queryName && queryName !== '') {
     query.parameters.neuron_name = queryName;
   } else {

--- a/src/js/plugins/views/NeuroglancerView.jsx
+++ b/src/js/plugins/views/NeuroglancerView.jsx
@@ -72,29 +72,20 @@ export default function NeuroGlancerView({ query }) {
 
   // load the layers for the dataset
   useEffect(() => {
-    fetch(`/api/npexplorer/nglayers/${dataset}.json`, {
-      headers: {
-        'content-type': 'application/json',
-        Accept: 'application/json',
-      },
-      method: 'GET',
-      credentials: 'include',
-    })
-      .then((response) => response.json())
-      .then((json) => {
-        setNgViewerState((prevState) => {
-          // grab the previous state for the current dataset and merge with the json
-          const prevDatasetState = prevState[dataset] || defaultViewerState;
-          const newDatasetState = { ...prevDatasetState, ...json };
-          const newState = { ...prevState, [dataset]: newDatasetState };
-          return newState;
-        });
-        setLayersLoading(false);
-      })
-      .catch((error) => {
-        setLoadingError(error);
+    const incommingState = query?.result?.data
+    try {
+      setNgViewerState((prevState) => {
+        // grab the previous state for the current dataset and merge with the json
+        const prevDatasetState = prevState[dataset] || defaultViewerState;
+        const newDatasetState = { ...prevDatasetState, ...incommingState };
+        const newState = { ...prevState, [dataset]: newDatasetState };
+        return newState;
       });
-  }, [dataset, setNgViewerState]);
+      setLayersLoading(false);
+    } catch (error) {
+      setLoadingError(error);
+    };
+  }, [dataset, setNgViewerState, query]);
 
   // add the bodyIds to the layer segments
   useEffect(() => {

--- a/src/js/plugins/views/NeuroglancerView.jsx
+++ b/src/js/plugins/views/NeuroglancerView.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useCallback, useMemo, useState, useEffect, Suspense } from 'react';
 import PropTypes from 'prop-types';
 import { setQueryString, getQueryObject } from 'helpers/queryString';
-import { NgViewerContext } from '../../contexts/NgViewerContext';
+import { NgViewerContext } from 'contexts/NgViewerContext';
 
 const Neuroglancer = React.lazy(() => import('@janelia-flyem/react-neuroglancer'));
 

--- a/src/js/reducers/3Dviewer.js
+++ b/src/js/reducers/3Dviewer.js
@@ -45,7 +45,6 @@ function addNeuronglancerToQuery(action, priorQuery) {
       ds: action.dataSet,
       pm: {
         dataset: action.dataSet,
-        skip: true,
         bodyIds: action.id,
       },
     });

--- a/src/js/reducers/neuroglancer.js
+++ b/src/js/reducers/neuroglancer.js
@@ -59,7 +59,6 @@ export default function neuroglancerReducer(state = neuroglancerState, action) {
           ds: action.dataSet,
           pm: {
             dataset: action.dataSet,
-            skip: true,
             bodyIds: action.id
           }
         });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,6 +99,7 @@ module.exports = {
       containers: path.resolve(__dirname, 'src/js/containers'),
       components: path.resolve(__dirname, 'src/js/components'),
       helpers: path.resolve(__dirname, 'src/js/helpers'),
+      contexts: path.resolve(__dirname, 'src/js/contexts'),
       plugins: path.resolve(__dirname, 'src/js/plugins'),
       views: path.resolve(__dirname, 'src/js/components/view-plugins'),
       actions: path.resolve(__dirname, 'src/js/actions')


### PR DESCRIPTION
The following commits make it possible to call actions on the neuroglancer viewer from the top bar menu.

- **feat: Adds action items to neuroglancer top bar menu.**
- **dev: Result component returns early on error.**
- **fix: Moves neuroglancer data loading out of NeuroGlancerView**
- **feat: neuroglancer actions menu now configured by nglayers data.**

Custom menu options for the neuroglancer viewer are defined in the nglayers json that is loaded from neuprintHTTP
to create one of these add the "neuprintMenuOptions": [] to the top level of the nglayers object

each menu option should have the following fields:
 - name: the name of the menu option that will be displayed
 - stateUpdate: an object that will be merged with the top level of the neuroglancer state

 or

 - name: the name of the menu option that will be displayed
 - layerUpdate: an object that will be merged with the layer specified by layerName
 - layerName: the name of the layer to update

 or

 - name: the name of the menu option that will be displayed
 - layerName: the name of the layer to update
 - attributeToToggle: the attribute to toggle on the layer specified by layerName

here are some examples:
``` json
 {
 "name": "Toggle Segmentation",
 "layerName": "segmentation",
 "attributeToToggle": "visible"
}
```
``` json
{
 "name": "Show Segmentation",
 "layerName": "segmentation",
 "layerUpdate": {
   "visible": true
 }
}
```
``` json
{
 "name": "reset view",
 "stateUpdate": {
   "position": [
     0 , 0, 0
   ],
   "projectionOrientation": [
     0, 0, 0, 1
   ],
   "projectionScale": 8000
 }
}
```

The last two commits improve the stability of the result component.

- **fix: prevents crash when last result tab is closed.**
- **fix: temporary fix to revert all neuron_id requests to integers**


@stuarteberg 