### PR TITLE
fix Cypher query for Find Neurons auto-suggest

### DIFF
--- a/src/js/plugins/query/shared/NeuronInputField.jsx
+++ b/src/js/plugins/query/shared/NeuronInputField.jsx
@@ -65,7 +65,7 @@ class NeuronInputField extends React.Component {
 
     const cypherString = `WITH
     toLower('${inputValue}') as q,
-    ${bodyId} as user_body
+    '${bodyId}' as user_body
 MATCH (n :Neuron)
 WHERE
     n.bodyId = user_body


### PR DESCRIPTION
Quoting the bodyId fixed auto suggest in "Find neurons" query type on testing. @neomorphic @stuarteberg 