### PR TITLE
feat: Adds warning for unsafe large numbers in JSON responses

### DIFF
--- a/src/js/helpers/numberUtils.js
+++ b/src/js/helpers/numberUtils.js
@@ -1,0 +1,52 @@
+// Utility functions for handling large numbers in JSON responses
+
+/**
+ * Checks if a number is too large to be safely represented in JavaScript
+ * JavaScript can safely represent integers up to Number.MAX_SAFE_INTEGER (2^53 - 1)
+ */
+export function isUnsafeNumber(value) {
+  return typeof value === 'number' && !Number.isSafeInteger(value);
+}
+
+/**
+ * Recursively checks an object or array for unsafe numbers
+ * Returns an array of paths where unsafe numbers are found
+ */
+export function findUnsafeNumbers(obj, path = '') {
+  const unsafePaths = [];
+
+  if (Array.isArray(obj)) {
+    obj.forEach((item, index) => {
+      const currentPath = path ? `${path}[${index}]` : `[${index}]`;
+      if (isUnsafeNumber(item)) {
+        unsafePaths.push(currentPath);
+      } else if (typeof item === 'object' && item !== null) {
+        unsafePaths.push(...findUnsafeNumbers(item, currentPath));
+      }
+    });
+  } else if (typeof obj === 'object' && obj !== null) {
+    Object.keys(obj).forEach(key => {
+      const currentPath = path ? `${path}.${key}` : key;
+      const value = obj[key];
+      if (isUnsafeNumber(value)) {
+        unsafePaths.push(currentPath);
+      } else if (typeof value === 'object' && value !== null) {
+        unsafePaths.push(...findUnsafeNumbers(value, currentPath));
+      }
+    });
+  }
+
+  return unsafePaths;
+}
+
+/**
+ * Checks if a JSON response contains numbers that are too large for JavaScript
+ * Returns an object with hasUnsafeNumbers boolean and array of paths
+ */
+export function checkForUnsafeNumbers(jsonResponse) {
+  const unsafePaths = findUnsafeNumbers(jsonResponse);
+  return {
+    hasUnsafeNumbers: unsafePaths.length > 0,
+    unsafePaths
+  };
+}

--- a/src/js/helpers/numberUtils.test.js
+++ b/src/js/helpers/numberUtils.test.js
@@ -1,0 +1,131 @@
+import { isUnsafeNumber, findUnsafeNumbers, checkForUnsafeNumbers } from './numberUtils';
+
+describe('numberUtils', () => {
+  describe('isUnsafeNumber', () => {
+    it('should identify safe numbers as safe', () => {
+      expect(isUnsafeNumber(42)).toBe(false);
+      expect(isUnsafeNumber(0)).toBe(false);
+      expect(isUnsafeNumber(-1)).toBe(false);
+      expect(isUnsafeNumber(Number.MAX_SAFE_INTEGER)).toBe(false);
+      expect(isUnsafeNumber(Number.MIN_SAFE_INTEGER)).toBe(false);
+    });
+
+    it('should identify unsafe numbers as unsafe', () => {
+      expect(isUnsafeNumber(Number.MAX_SAFE_INTEGER + 1)).toBe(true);
+      expect(isUnsafeNumber(Number.MIN_SAFE_INTEGER - 1)).toBe(true);
+      expect(isUnsafeNumber(Number.MAX_VALUE)).toBe(true);
+    });
+
+    it('should handle non-numbers', () => {
+      expect(isUnsafeNumber('123')).toBe(false);
+      expect(isUnsafeNumber(null)).toBe(false);
+      expect(isUnsafeNumber(undefined)).toBe(false);
+      expect(isUnsafeNumber({})).toBe(false);
+    });
+
+    it('should NOT flag large numbers when they are strings', () => {
+      const largeNumberAsString = (Number.MAX_SAFE_INTEGER + 1).toString();
+      expect(isUnsafeNumber(largeNumberAsString)).toBe(false);
+      expect(isUnsafeNumber('9007199254740992')).toBe(false); // 2^53
+      expect(isUnsafeNumber('999999999999999999999999')).toBe(false); // Very large number as string
+    });
+  });
+
+  describe('findUnsafeNumbers', () => {
+    it('should find unsafe numbers in simple objects', () => {
+      const obj = {
+        safe: 42,
+        unsafe: Number.MAX_SAFE_INTEGER + 1
+      };
+      const result = findUnsafeNumbers(obj);
+      expect(result).toEqual(['unsafe']);
+    });
+
+    it('should find unsafe numbers in nested objects', () => {
+      const obj = {
+        level1: {
+          level2: {
+            unsafe: Number.MAX_SAFE_INTEGER + 1,
+            safe: 42
+          }
+        }
+      };
+      const result = findUnsafeNumbers(obj);
+      expect(result).toEqual(['level1.level2.unsafe']);
+    });
+
+    it('should find unsafe numbers in arrays', () => {
+      const arr = [42, Number.MAX_SAFE_INTEGER + 1, 'safe'];
+      const result = findUnsafeNumbers(arr);
+      expect(result).toEqual(['[1]']);
+    });
+
+    it('should find unsafe numbers in complex nested structures', () => {
+      const obj = {
+        data: [
+          { id: 1, value: 42 },
+          { id: Number.MAX_SAFE_INTEGER + 1, value: 'test' }
+        ],
+        metadata: {
+          count: Number.MAX_SAFE_INTEGER + 2
+        }
+      };
+      const result = findUnsafeNumbers(obj);
+      expect(result).toContain('data[1].id');
+      expect(result).toContain('metadata.count');
+    });
+
+    it('should NOT flag large numbers when they are strings in complex structures', () => {
+      const obj = {
+        data: [
+          { id: '9007199254740992', value: 42 }, // Large number as string - should be ignored
+          { id: Number.MAX_SAFE_INTEGER + 1, value: 'test' } // Actual unsafe number
+        ],
+        metadata: {
+          count: '999999999999999999999999', // Very large number as string - should be ignored
+          unsafeCount: Number.MAX_SAFE_INTEGER + 2 // Actual unsafe number
+        }
+      };
+      const result = findUnsafeNumbers(obj);
+      expect(result).not.toContain('data[0].id'); // String should be ignored
+      expect(result).not.toContain('metadata.count'); // String should be ignored
+      expect(result).toContain('data[1].id'); // Actual number should be flagged
+      expect(result).toContain('metadata.unsafeCount'); // Actual number should be flagged
+    });
+  });
+
+  describe('checkForUnsafeNumbers', () => {
+    it('should return false for safe responses', () => {
+      const response = {
+        data: [[1, 2, 3], ['a', 'b', 'c']],
+        columns: ['col1', 'col2', 'col3']
+      };
+      const result = checkForUnsafeNumbers(response);
+      expect(result.hasUnsafeNumbers).toBe(false);
+      expect(result.unsafePaths).toEqual([]);
+    });
+
+    it('should return true for unsafe responses', () => {
+      const response = {
+        data: [[Number.MAX_SAFE_INTEGER + 1, 2, 3]],
+        columns: ['col1', 'col2', 'col3']
+      };
+      const result = checkForUnsafeNumbers(response);
+      expect(result.hasUnsafeNumbers).toBe(true);
+      expect(result.unsafePaths).toContain('data[0][0]');
+    });
+
+    it('should return false when large numbers are strings', () => {
+      const response = {
+        data: [['9007199254740992', 2, 3]], // Large number as string
+        columns: ['col1', 'col2', 'col3'],
+        metadata: {
+          largeId: '999999999999999999999999' // Very large number as string
+        }
+      };
+      const result = checkForUnsafeNumbers(response);
+      expect(result.hasUnsafeNumbers).toBe(false);
+      expect(result.unsafePaths).toEqual([]);
+    });
+  });
+});

--- a/src/js/plugins/query/CustomQuery.jsx
+++ b/src/js/plugins/query/CustomQuery.jsx
@@ -75,12 +75,19 @@ export class CustomQuery extends React.Component {
       const data = apiResponse.data.map(row =>
         row.map(item => (typeof item === 'object' ? JSON.stringify(item) : item))
       );
-      return {
+      const result = {
         columns: apiResponse.columns,
         data,
         debug: apiResponse.debug,
         title: 'Custom Query'
       };
+
+      // Pass through the unsafe number warning if present
+      if (apiResponse.unsafeNumberWarning) {
+        result.unsafeNumberWarning = apiResponse.unsafeNumberWarning;
+      }
+
+      return result;
     }
     return {
       columns: [],

--- a/src/js/plugins/views/SimpleTable.jsx
+++ b/src/js/plugins/views/SimpleTable.jsx
@@ -9,6 +9,7 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import TablePagination from '@mui/material/TablePagination';
 import TableSortLabel from '@mui/material/TableSortLabel';
+import Alert from '@mui/material/Alert';
 import withStyles from '@mui/styles/withStyles';
 
 import { TablePaginationActions } from 'plugins/support';
@@ -146,6 +147,13 @@ class SimpleTable extends React.Component {
             onChange={index => this.handleColumnChange(index)}
             dataSet={query.pm.dataset}
           />
+
+          {result.unsafeNumberWarning ? (
+            <Alert severity="warning" style={{ marginBottom: '16px' }}>
+              {result.unsafeNumberWarning.message}
+            </Alert>
+          ) : null}
+
           {paginate ? (
             <TablePagination
               component="div"


### PR DESCRIPTION
- Adds numberUtils helper to detect JavaScript unsafe integers
- Integrates number checking into plugin response pipeline
- Displays warning alert in SimpleTable when unsafe numbers detected
- Updates CustomQuery to pass through unsafe number warnings

Helps prevent data accuracy issues when large numbers exceed
JavaScript's MAX_SAFE_INTEGER (2^53 - 1) and get rounded.

@stuarteberg @krokicki