### PR TITLE
logout: top-level navigation instead of fetch chain

### DIFF
--- a/src/js/components/Login.jsx
+++ b/src/js/components/Login.jsx
@@ -109,10 +109,7 @@ class Login extends React.Component {
     const { logoutUser } = this.props;
     this.setState({ isLoggedIn: false });
     logoutUser();
-    // POST to /logout so the server can clear the HttpOnly dsg_token
-    // cookie via DSG's logout endpoint.
-    fetch('/logout', { method: 'POST', credentials: 'include' })
-      .finally(() => { window.location = '/'; });
+    window.location.assign('/logout');
   };
 
   launchUserPopup = event => {

--- a/src/js/reducers/user.js
+++ b/src/js/reducers/user.js
@@ -31,7 +31,7 @@ export default function userReducer(state = userState, action) {
     }
     case C.LOGOUT_USER: {
       // clear the login cookie(s) here.
-      // Note: dsg_token is HttpOnly — cleared server-side via POST /logout
+      // Note: dsg_token is HttpOnly — cleared server-side via top-level /logout navigation
       Cookies.remove('neuPrintHTTP');
       Cookies.remove('neuPrintHTTP', { path: '/', domain: '.janelia.org' });
       Cookies.remove('neuPrintHTTP', { path: '/', domain: window.location.hostname });


### PR DESCRIPTION
## What

Replaces the `fetch POST /logout` chain in `Login.jsx` with a plain `window.location.assign('/logout')`, and updates the stale comment in the user reducer. Net −3 lines.

## Why

The fetch-based logout has never actually cleared the session cookie: the server 302s to DatasetGateway's logout, the browser follows it cross-origin inside the fetch, and the response is CORS-discarded — the HttpOnly `dsg_token` cookie survives. A top-level document navigation lets DSG clear the domain-wide cookie and redirect back.

Client-side cleanup (`logoutUser` dispatch, `neuPrintHTTP` cookie removal) still runs before navigating, unchanged.

## Server pairing

Pairs with connectome-neuprint/neuPrintHTTP@ceb7efa (already on master): `/logout` gains a GET route, moves outside the DSG auth middleware (a stale cookie must reach the redirect, not 401), and sends an absolute, query-encoded redirect through DSG. The full flow also needs the DatasetGateway side (`?redirect=` support on its logout) deployed — rollout is sequenced DSG-first, so merging this ahead of that deploy is safe: until DSG updates, behavior is no worse than today.

Intended to ship in the next Explorer release (1.72.0 train) together with the announcement-banner work.

## Testing

`npm test`: 33/33 suites, 159/159 tests, 12/12 snapshots (ESLint pretest clean).